### PR TITLE
Add HeatSetNuts from Aliexpress and allow nut size to have more than 3 parts

### DIFF
--- a/src/bd_warehouse/data/heatset_nut_parameters.csv
+++ b/src/bd_warehouse/data/heatset_nut_parameters.csv
@@ -1,23 +1,121 @@
-Size,McMaster-Carr:s,McMaster-Carr:m,McMaster-Carr:dc,McMaster-Carr:knurls,McMaster-Carr:material_thickness,McMaster-Carr:drill,McMaster-Carr:part,Hilitchi:s,Hilitchi:m,Hilitchi:dc,Hilitchi:knurls,Hilitchi:material_thickness,Hilitchi:drill,Hilitchi:part
-M2-0.4-Short,3.6,2.5,3.1,20,3.3,#30, 94459A110,,,,,,,
-M2-0.4-Standard,3.6,4,3.1,20,4.7,#30, 94459A120,,,,,,,
-M3-0.5-Short,4.7,4.3,3.9,20,5.1,#21, 94459A130,,,,,,,
-M3-0.5-Standard,4.7,5.7,3.9,20,6.5,#21, 94459A140,,,,,,,
-M4-0.7-Short,6.3,4.7,5.5,20,5.5,#2, 94459A150,,,,,,,
-M4-0.7-Standard,6.3,8.2,5.5,20,8.9,#2, 94459A170,,,,,,,
-M5-0.8-Standard,7.1,9.5,6.3,20,10.3, F, 94459A180,,,,,,,
-M2-0.4-3,,,,,,,,3.5,3,2.9,20,3.8,#30,H-THM300
-M2-0.4-4,,,,,,,,3.5,4,2.9,20,4.8,#30,H-THM300
-M2-0.4-6,,,,,,,,3.5,6,2.9,20,6.8,#30,H-THM300
-M2-0.4-8,,,,,,,,3.5,8,2.9,20,8.8,#30,H-THM300
-M3-0.5-6,,,,,,,,5,6,4.3,20,6.8,#21,H-THM300
-M3-0.5-8,,,,,,,,5,8,4.3,20,8.8,#21,H-THM300
-M3-0.5-10,,,,,,,,5,10,4.3,20,10.8,#21,H-THM300
-M4-0.7-8,,,,,,,,6,8,5.3,20,8.8,#2,H-THM300
-M4-0.7-6,,,,,,,,6,6,5.3,20,6.8,#2,H-THM300
-M4-0.7-10,,,,,,,,6,10,5.3,20,10.8,#2,H-THM300
-M5-0.8-6,,,,,,,,7,6,6.3,20,6.8,F,H-THM300
-M5-0.8-8,,,,,,,,7,8,6.3,20,8.8,F,H-THM300
-M5-0.8-10,,,,,,,,7,10,6.3,20,10.8,F,H-THM300
-M6-1-10,,,,,,,,8,10,7.3,20,10.8,M,H-THM300
-M6-1-12,,,,,,,,8,12,7.3,20,12.8,M,H-THM300
+Size,McMaster-Carr:s,McMaster-Carr:m,McMaster-Carr:dc,McMaster-Carr:knurls,McMaster-Carr:material_thickness,McMaster-Carr:drill,McMaster-Carr:part,Hilitchi:s,Hilitchi:m,Hilitchi:dc,Hilitchi:knurls,Hilitchi:material_thickness,Hilitchi:drill,Hilitchi:part,AE-SamZhihui:s,AE-SamZhihui:m,AE-SamZhihui:dc,AE-SamZhihui:knurls,AE-SamZhihui:material_thickness,AE-SamZhihui:drill,AE-SamZhihui:part
+M2-0.4-Short,3.6,2.5,3.1,20,3.3,#30, 94459A110,,,,,,,,,,,,,,
+M2-0.4-Standard,3.6,4,3.1,20,4.7,#30, 94459A120,,,,,,,,,,,,,,
+M3-0.5-Short,4.7,4.3,3.9,20,5.1,#21, 94459A130,,,,,,,,,,,,,,
+M3-0.5-Standard,4.7,5.7,3.9,20,6.5,#21, 94459A140,,,,,,,,,,,,,,
+M4-0.7-Short,6.3,4.7,5.5,20,5.5,#2, 94459A150,,,,,,,,,,,,,,
+M4-0.7-Standard,6.3,8.2,5.5,20,8.9,#2, 94459A170,,,,,,,,,,,,,,
+M5-0.8-Standard,7.1,9.5,6.3,20,10.3, F, 94459A180,,,,,,,,,,,,,,
+M2-0.4-3,,,,,,,,3.5,3,2.9,20,3.8,#30,H-THM300,,,,,,,
+M2-0.4-4,,,,,,,,3.5,4,2.9,20,4.8,#30,H-THM300,,,,,,,
+M2-0.4-6,,,,,,,,3.5,6,2.9,20,6.8,#30,H-THM300,,,,,,,
+M2-0.4-8,,,,,,,,3.5,8,2.9,20,8.8,#30,H-THM300,,,,,,,
+M3-0.5-6,,,,,,,,5,6,4.3,20,6.8,#21,H-THM300,,,,,,,
+M3-0.5-8,,,,,,,,5,8,4.3,20,8.8,#21,H-THM300,,,,,,,
+M3-0.5-10,,,,,,,,5,10,4.3,20,10.8,#21,H-THM300,,,,,,,
+M4-0.7-8,,,,,,,,6,8,5.3,20,8.8,#2,H-THM300,,,,,,,
+M4-0.7-6,,,,,,,,6,6,5.3,20,6.8,#2,H-THM300,,,,,,,
+M4-0.7-10,,,,,,,,6,10,5.3,20,10.8,#2,H-THM300,,,,,,,
+M5-0.8-6,,,,,,,,7,6,6.3,20,6.8,F,H-THM300,,,,,,,
+M5-0.8-8,,,,,,,,7,8,6.3,20,8.8,F,H-THM300,,,,,,,
+M5-0.8-10,,,,,,,,7,10,6.3,20,10.8,F,H-THM300,,,,,,,
+M6-1-10,,,,,,,,8,10,7.3,20,10.8,M,H-THM300,,,,,,,
+M6-1-12,,,,,,,,8,12,7.3,20,12.8,M,H-THM300,,,,,,,
+M1.4-0.3-H1.5-D2.3,,,,,,,,,,,,,,,2.3,1.5,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.4-0.3-H2-D2.3,,,,,,,,,,,,,,,2.3,2,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.4-0.3-H3-D2.3,,,,,,,,,,,,,,,2.3,3,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.4-0.3-H4-D2.3,,,,,,,,,,,,,,,2.3,4,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.4-0.3-H5-D2.3,,,,,,,,,,,,,,,2.3,5,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.4-0.3-H6-D2.3,,,,,,,,,,,,,,,2.3,6,1.9,20,0,#47,https://www.aliexpress.com/item/1005005220632314.html
+M1.6-0.35-H2-D2.5,,,,,,,,,,,,,,,2.5,2,2,20,0,#45,https://www.aliexpress.com/item/1005005220632314.html
+M1.6-0.35-H3-D2.5,,,,,,,,,,,,,,,2.5,3,2,20,0,#45,https://www.aliexpress.com/item/1005005220632314.html
+M1.6-0.35-H4-D2.5,,,,,,,,,,,,,,,2.5,4,2,20,0,#45,https://www.aliexpress.com/item/1005005220632314.html
+M1.6-0.35-H5-D2.5,,,,,,,,,,,,,,,2.5,5,2,20,0,#45,https://www.aliexpress.com/item/1005005220632314.html
+M1.6-0.35-H6-D2.5,,,,,,,,,,,,,,,2.5,6,2,20,0,#45,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H2-D3,,,,,,,,,,,,,,,3,2,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H3-D3,,,,,,,,,,,,,,,3,3,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H4-D3,,,,,,,,,,,,,,,3,4,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H5-D3,,,,,,,,,,,,,,,3,5,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H6-D3,,,,,,,,,,,,,,,3,6,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H8-D3,,,,,,,,,,,,,,,3,8,2.68,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H2-D3.2,,,,,,,,,,,,,,,3.2,2,2.81,20,0,#32,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H3-D3.2,,,,,,,,,,,,,,,3.2,3,2.81,20,0,#33,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H4-D3.2,,,,,,,,,,,,,,,3.2,4,2.81,20,0,#34,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H5-D3.2,,,,,,,,,,,,,,,3.2,5,2.81,20,0,#35,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H6-D3.2,,,,,,,,,,,,,,,3.2,6,2.81,20,0,#36,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H8-D3.2,,,,,,,,,,,,,,,3.2,8,2.81,20,0,#37,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H2-D3.5,,,,,,,,,,,,,,,3.5,2,3.03,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H3-D3.5,,,,,,,,,,,,,,,3.5,3,3.03,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H4-D3.5,,,,,,,,,,,,,,,3.5,4,3.03,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H5-D3.5,,,,,,,,,,,,,,,3.5,5,3.03,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2-0.4-H6-D3.5,,,,,,,,,,,,,,,3.5,6,3.03,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H2-D3.5,,,,,,,,,,,,,,,3.5,2,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H3-D3.5,,,,,,,,,,,,,,,3.5,3,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H4-D3.5,,,,,,,,,,,,,,,3.5,4,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H5-D3.5,,,,,,,,,,,,,,,3.5,5,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H6-D3.5,,,,,,,,,,,,,,,3.5,6,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H7-D3.5,,,,,,,,,,,,,,,3.5,7,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H8-D3.5,,,,,,,,,,,,,,,3.5,8,3.04,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H2-D4,,,,,,,,,,,,,,,4,2,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H3-D4,,,,,,,,,,,,,,,4,3,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H4-D4,,,,,,,,,,,,,,,4,4,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H5-D4,,,,,,,,,,,,,,,4,5,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H6-D4,,,,,,,,,,,,,,,4,6,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H7-D4,,,,,,,,,,,,,,,4,7,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H8-D4,,,,,,,,,,,,,,,4,8,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M2.5-0.45-H8-D4,,,,,,,,,,,,,,,4,8,3.44,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H3-D4.2,,,,,,,,,,,,,,,4.2,3,3.74,20,0,#24,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H4-D4.2,,,,,,,,,,,,,,,4.2,4,3.74,20,0,#25,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H5-D4.2,,,,,,,,,,,,,,,4.2,5,3.74,20,0,#26,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H6-D4.2,,,,,,,,,,,,,,,4.2,6,3.74,20,0,#27,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H7-D4.2,,,,,,,,,,,,,,,4.2,7,3.74,20,0,#28,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H8-D4.2,,,,,,,,,,,,,,,4.2,8,3.74,20,0,#29,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H9-D4.2,,,,,,,,,,,,,,,4.2,9,3.74,20,0,#30,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H10-D4.2,,,,,,,,,,,,,,,4.2,10,3.74,20,0,#31,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H3-D4.5,,,,,,,,,,,,,,,4.5,3,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H4-D4.5,,,,,,,,,,,,,,,4.5,4,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H5-D4.5,,,,,,,,,,,,,,,4.5,5,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H6-D4.5,,,,,,,,,,,,,,,4.5,6,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H7-D4.5,,,,,,,,,,,,,,,4.5,7,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H8-D4.5,,,,,,,,,,,,,,,4.5,8,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H9-D4.5,,,,,,,,,,,,,,,4.5,9,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H10-D4.5,,,,,,,,,,,,,,,4.5,10,3.9,20,0,#22,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H3-D5,,,,,,,,,,,,,,,5,3,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H4-D5,,,,,,,,,,,,,,,5,4,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H5-D5,,,,,,,,,,,,,,,5,5,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H6-D5,,,,,,,,,,,,,,,5,6,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H7-D5,,,,,,,,,,,,,,,5,7,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H8-D5,,,,,,,,,,,,,,,5,8,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H9-D5,,,,,,,,,,,,,,,5,9,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M3-0.5-H10-D5,,,,,,,,,,,,,,,5,10,4.17,20,0,#18,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H4-D6,,,,,,,,,,,,,,,6,4,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H5-D6,,,,,,,,,,,,,,,6,5,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H6-D6,,,,,,,,,,,,,,,6,6,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H7-D6,,,,,,,,,,,,,,,6,7,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H8-D6,,,,,,,,,,,,,,,6,8,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H9-D6,,,,,,,,,,,,,,,6,9,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H10-D6,,,,,,,,,,,,,,,6,10,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M4-0.7-H12-D6,,,,,,,,,,,,,,,6,12,5.33,20,0,#3,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H4-D7,,,,,,,,,,,,,,,7,4,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H5-D7,,,,,,,,,,,,,,,7,5,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H6-D7,,,,,,,,,,,,,,,7,6,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H7-D7,,,,,,,,,,,,,,,7,7,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H8-D7,,,,,,,,,,,,,,,7,8,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H9-D7,,,,,,,,,,,,,,,7,9,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H10-D7,,,,,,,,,,,,,,,7,10,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H11-D7,,,,,,,,,,,,,,,7,11,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H12-D7,,,,,,,,,,,,,,,7,12,6.12,20,0,D,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H5-D8,,,,,,,,,,,,,,,8,5,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H6-D8,,,,,,,,,,,,,,,8,6,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H7-D8,,,,,,,,,,,,,,,8,7,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H8-D8,,,,,,,,,,,,,,,8,8,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H9-D8,,,,,,,,,,,,,,,8,9,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M5-0.8-H10-D8,,,,,,,,,,,,,,,8,10,6.97,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H4-D8,,,,,,,,,,,,,,,8,4,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H5-D8,,,,,,,,,,,,,,,8,5,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H6-D8,,,,,,,,,,,,,,,8,6,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H7-D8,,,,,,,,,,,,,,,8,7,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H8-D8,,,,,,,,,,,,,,,8,8,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H9-D8,,,,,,,,,,,,,,,8,9,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H10-D8,,,,,,,,,,,,,,,8,10,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html
+M6-1-H11-D8,,,,,,,,,,,,,,,8,11,7.09,20,0,K,https://www.aliexpress.com/item/1005005220632314.html

--- a/src/bd_warehouse/fastener.py
+++ b/src/bd_warehouse/fastener.py
@@ -544,7 +544,7 @@ class Nut(ABC, BasePartObject):
                 f"{size_parts} invalid, must be formatted as size-pitch(-length) or size-TPI(-length) where length is optional"
             )
         self.thread_size = "-".join(size_parts[:2])
-        if len(size_parts) == 3:
+        if len(size_parts) >= 3:
             self.length_size = size_parts[2]
         self.is_metric = self.thread_size[0] == "M"
         if self.is_metric:


### PR DESCRIPTION
As per @gumyr  request, I am breaking up the pull request #25 from @infused-kim.

Here is the first part of his pull request.  Once this PR is done, I will process the balance of the PR #25 

1. HeatSetNuts from AliExpress
They can be purchased here: https://www.aliexpress.com/item/1005005220632314.html

It seems like there are multiple stores / brands that sell the same nuts (same dimensions and images). I picked this one, because he has the largest selection, a large amount of sales and was fast to respond in the support chat.

You can also find the spreadsheet I used to edit the data here:
https://docs.google.com/spreadsheets/d/1ZpZ6ltspaA5y2Nw6DH-3abuv4ToLoAWX3zQu_ON2lfs/edit?gid=0#gid=0

2. Allow nut size to have more than 3 parts
Some of the AE nuts had the same size thread size and height, but different variations in the outer diameter, such as M2-0.4-H2-D3.2 and M2-0.4-H2-D3.5 (outer diameter 3.2 vs 3.5).

So, I added another - to distinguish between them.

But then the code stopped populating length_size:

` if len(size_parts) == 3:
            self.length_size = size_parts[2]`
       
So, I changed it to allow more than 3 parts.