### PR TITLE
Fix pyproject classifiers and description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dynamic = ["version"]
 authors = [
     {name = "Roger Maitland", email = "gumyr9@gmail.com"},
 ]
-description = "A python CAD programming library "
+description = "A build123d parametric part collection"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
 ]
 license = {text = "Apache-2.0"}
 classifiers = [
-    "License :: OSI Approved :: Apache-2.0 License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
The project description hadn't been updated, and the license classifier wasn't a valid trove-classifier (was causing the build to fail here).