### PR TITLE
readthedocs builds: stability improvements, enable epub/pdf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,9 @@
 version: 2
 
+formats:
+  - epub
+  - pdf
+
 build:
   os: "ubuntu-22.04"
   tools:
@@ -14,4 +18,7 @@ sphinx:
 # Explicitly set the version of Python and its requirements
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+# TODO: delete this file as it is no longer used to build the docs
 # Defining the exact version will make sure things don't break
 sphinx==5.3.0
 sphinx_rtd_theme>=0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,17 @@ dependencies = [
     "typing_extensions >= 4.4.0, <5",
 ]
 
+[project.optional-dependencies]
+# dependencies to build the docs
+docs = [
+    "sphinx==8.1.3", # pin for stability of docs builds
+    "sphinx-design",
+    "sphinx-copybutton",
+    "sphinx-hoverxref",
+    "sphinx-rtd-theme",
+    "sphinx-autodoc-typehints",
+]
+
 [tool.setuptools]
 # ...
 # By default, include-package-data is true in pyproject.toml, so you do


### PR DESCRIPTION
This PR brings bd-warehouse more in line with the way the docs are built on build123d using the optional dependencies in `pyproject.toml` rather than a separate `requirements.txt`. The only downside I am aware of is that this setup will now install latest stable build123d (0.9.1 as of writing) instead of the latest from github. Is that a concern? It may be possible to bring that back using some config settings in `.readthedocs.yaml` but I haven't dug deeply into that yet.

I also took the opportunity to add PDF/EPUB builds.