### PR TITLE
Adding feature to rotate clearance holes

### DIFF
--- a/src/bd_warehouse/fastener.py
+++ b/src/bd_warehouse/fastener.py
@@ -3346,6 +3346,7 @@ class ClearanceHole(BasePartObject):
         counter_sunk (bool, optional): Is the fastener countersunk into the part?.
             Defaults to True.
         captive_nut (bool, optional): Is rotation of the nut disabled?. Defaults to False.
+        rotation (RotationLike, optional): object rotation. Defaults to (0, 0, 0).
         mode (Mode, optional): combination mode. Defaults to Mode.SUBTRACT.
 
     Raises:
@@ -3363,6 +3364,7 @@ class ClearanceHole(BasePartObject):
         depth: float = None,
         counter_sunk: bool = True,
         captive_nut: bool = False,
+        rotation: RotationLike = (0, 0, 0),
         mode: Mode = Mode.SUBTRACT,
     ):
         context: BuildPart = BuildPart._get_context(self)
@@ -3401,7 +3403,7 @@ class ClearanceHole(BasePartObject):
         super().__init__(
             part=hole_part,
             align=None,
-            rotation=(0, 0, 0),
+            rotation=rotation,
             mode=mode,
         )
 


### PR DESCRIPTION
I need to rotate clearance holes to achieve best fit into a slim part. The current implementation does not provide an easy way to do this.

Desired result:
<img height="320" alt="image" src="https://github.com/user-attachments/assets/7dce7b71-95e9-43f4-aa93-8b412e95dfea" />

Possible result:
<img  height="320" alt="image" src="https://github.com/user-attachments/assets/1de4615f-1651-44d6-9a31-c2ae8cf1df75" />

This PR extends the `ClearanceHole` class with a new argument:
- `rotation (RotationLike, optional): object rotation. Defaults to (0, 0, 0).`
  Enables explicit rotation of the clearance hole.