### PR TITLE
Adding b-joint to screws

### DIFF
--- a/src/bd_warehouse/fastener.py
+++ b/src/bd_warehouse/fastener.py
@@ -66,7 +66,10 @@ from build123d.geometry import (
     RotationLike,
     Vector,
 )
-from build123d.joints import RigidJoint
+from build123d.joints import (
+  CylindricalJoint,
+  RigidJoint
+)
 from build123d.objects_curve import (
     JernArc,
     Line,
@@ -1664,6 +1667,7 @@ class Screw(ABC, BasePartObject):
         )
         self.color = Color(0xC0C0C0)
         RigidJoint("a", self, Location())
+        CylindricalJoint("b", self, axis=Axis(self.faces().filter_by(Plane.XY).sort_by(Axis.Z)[0].center_location), linear_range=(-self.length + self.head_height, 0))
 
     def make_head(self) -> Solid:
         """Create a screw head from the 2D shapes defined in the derived class"""


### PR DESCRIPTION
This PR adds one things:

- CylindricalJoint-"b"-joint on the lowest Z-face of each screw

This allows to use joints for the following use cases:

- <img height="320" alt="image" src="https://github.com/user-attachments/assets/df977fd9-7a6a-4a43-99bd-1d514a152201" />
- <img height="320" alt="image" src="https://github.com/user-attachments/assets/ed84634e-bf60-4f9f-9b3e-0bc4d1710a79" />

I am not sure about the test design. I tried to apply the design of the existing test cases.
I'll change the tests when you're not happy with them. Just give me a hint.