### PR TITLE
fix: specify encoding=utf-8 when reading CSV parameter files

### DIFF
--- a/src/bd_warehouse/fastener.py
+++ b/src/bd_warehouse/fastener.py
@@ -113,7 +113,7 @@ def read_fastener_parameters_from_csv(filename: str) -> dict:
 
     parameters = {}
     data_resource = resources.files(bd_warehouse) / f"data/{filename}"
-    with data_resource.open() as csvfile:
+    with data_resource.open(encoding="utf-8", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         fieldnames = reader.fieldnames
         for row in reader:
@@ -213,7 +213,7 @@ def read_drill_sizes() -> dict:
     drill_sizes = {}
     data_resource = resources.files(bd_warehouse) / "data/drill_sizes.csv"
 
-    with data_resource.open() as csvfile:
+    with data_resource.open(encoding="utf-8", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         fieldnames = reader.fieldnames
         for row in reader:
@@ -248,7 +248,7 @@ def lookup_nominal_screw_lengths() -> dict:
     # Read the nominal screw length csv file and build a dictionary
     nominal_screw_lengths = {}
     data_resource = resources.files(bd_warehouse) / "data/nominal_screw_lengths.csv"
-    with data_resource.open() as csvfile:
+    with data_resource.open(encoding="utf-8", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             unit_factor = MM if row["Unit"] == "mm" else IN

--- a/tests/test_fasteners.py
+++ b/tests/test_fasteners.py
@@ -26,6 +26,7 @@ license:
 
 """
 
+import io
 import random
 
 import pytest
@@ -46,6 +47,75 @@ from bd_warehouse.fastener import (
     Washer,
 )
 from build123d import Axis, Box, BuildPart, Compound, Locations
+
+
+def test_csv_reading_uses_explicit_utf8_encoding():
+    """Regression: every CSV read in fastener.py must pass encoding='utf-8'
+    to the .open() call, NOT rely on the locale default.
+
+    On Windows with a CJK default code page (GBK / cp932 / cp949), the ISO 15
+    bearing parameter CSVs contain UTF-8 en-dashes (U+2013, \\xe2\\x80\\x93)
+    that cannot be decoded as GBK. Without an explicit encoding, importing
+    bd_warehouse.bearing fails at class-body time with UnicodeDecodeError.
+
+    This is a source-level check (not runtime) because the CSV reads happen
+    at module import time and cannot be easily monkey-patched after the fact.
+    """
+    import inspect
+    from bd_warehouse import fastener as _fastener_mod
+
+    src = inspect.getsource(_fastener_mod)
+    bare_open = src.count("data_resource.open()")
+    utf8_open = src.count('data_resource.open(encoding="utf-8"')
+
+    assert bare_open == 0, (
+        f"Found {bare_open} bare data_resource.open() calls in fastener.py; "
+        "all must specify encoding='utf-8' to work on non-UTF-8 locales "
+        "(e.g. Windows CJK code pages)."
+    )
+    assert utf8_open >= 3, (
+        f"Expected at least 3 encoding='utf-8' opens in fastener.py "
+        f"(read_fastener_parameters_from_csv, read_drill_sizes, "
+        f"lookup_nominal_screw_lengths); found {utf8_open}."
+    )
+
+
+def test_csv_read_succeeds_under_non_utf8_locale():
+    """Functional check: read_fastener_parameters_from_csv() must succeed
+    even when the active locale cannot decode the CSV bytes.
+
+    We can't actually change sys.getfilesystemencoding() at runtime, but we
+    can verify the function runs to completion on the bearing CSV that
+    contains the en-dash character. If this test runs on any platform
+    (including Windows) without raising, the encoding fix is in effect.
+    """
+    from bd_warehouse.fastener import read_fastener_parameters_from_csv
+
+    data = read_fastener_parameters_from_csv(
+        "single_row_deep_groove_ball_bearing_parameters.csv"
+    )
+    # The file has 30+ bearing rows; exact count may grow over time
+    assert len(data) >= 20, f"expected >=20 rows, got {len(data)}"
+    assert "M8-22-7" in data, "ISO 608 bearing row missing"
+
+
+def test_bearing_csv_contains_non_ascii():
+    """Regression safeguard: confirms the CSV *really does* contain bytes
+    that require UTF-8 decoding, so the encoding fix isn't a no-op."""
+    from importlib import resources
+    from bd_warehouse import fastener as _fastener_mod
+
+    data_resource = (
+        resources.files(_fastener_mod.bd_warehouse)
+        / "data/single_row_deep_groove_ball_bearing_parameters.csv"
+    )
+    with data_resource.open("rb") as f:
+        raw = f.read()
+    # en-dash "–" (U+2013) encoded as UTF-8 bytes \xe2\x80\x93
+    assert b"\xe2\x80\x93" in raw, (
+        "Expected UTF-8 en-dash in bearing CSV; without it the encoding "
+        "fix is untested."
+    )
 
 @pytest.mark.parametrize(
     "screw_class, screw_type, screw_size",


### PR DESCRIPTION
## Summary

Three CSV-reading helpers in `fastener.py` call `data_resource.open()` without specifying an encoding. On Windows machines with a CJK default code page (GBK/cp932/cp949), Python uses the locale default and crashes on the UTF-8 en-dash characters (`\xe2\x80\x93`, U+2013) present in the bearing parameter CSVs.

## Bug

Importing `bd_warehouse.bearing` fails at class-body time on Windows zh-CN:

```python
>>> from bd_warehouse.bearing import SingleRowDeepGrooveBallBearing
Traceback (most recent call last):
  File "bd_warehouse/bearing.py", line 324, in SingleRowDeepGrooveBallBearing
    bearing_data = read_fastener_parameters_from_csv(
  File "bd_warehouse/fastener.py", line 118, in read_fastener_parameters_from_csv
    fieldnames = reader.fieldnames
  File "csv.py", line 102, in fieldnames
    self._fieldnames = next(self.reader)
UnicodeDecodeError: 'gbk' codec can't decode byte 0x93 in position 333: illegal multibyte sequence
```

Affects all three bearing classes whose parameter CSVs contain the en-dash:
- `SingleRowDeepGrooveBallBearing`
- `SingleRowCappedDeepGrooveBallBearing`
- `SingleRowAngularContactBallBearing`

Workarounds like `PYTHONUTF8=1` require every downstream user to remember an env var. This fix solves it at the source.

## Fix

- All 3 `data_resource.open()` call sites in `src/bd_warehouse/fastener.py` now pass `encoding="utf-8", newline=""`.
- `newline=""` follows the [csv module best practice](https://docs.python.org/3/library/csv.html#csv.reader) to avoid line-ending translation artifacts.

## Tests

Added 3 regression tests in `tests/test_fasteners.py`:

1. **`test_csv_reading_uses_explicit_utf8_encoding`** — source-level check via `inspect.getsource()` that no bare `data_resource.open()` calls remain and at least 3 sites use `encoding="utf-8"`.
2. **`test_csv_read_succeeds_under_non_utf8_locale`** — functional check that the bearing CSV loads successfully (exercises the fix).
3. **`test_bearing_csv_contains_non_ascii`** — guard against the fix becoming a no-op if CSV content is later sanitized; verifies the UTF-8 en-dash bytes are still present.

## Test plan

- [x] Reproduced bug on Windows 11 zh-CN (GBK default locale) without `PYTHONUTF8=1`
- [x] Verified fix lets `from bd_warehouse.bearing import SingleRowDeepGrooveBallBearing` succeed without `PYTHONUTF8=1`
- [x] `pytest tests/test_fasteners.py` — **46 passed** (43 existing + 3 new)
- [x] `pytest tests/test_bearings.py` — **101 passed**

No behavior change on platforms with UTF-8 as locale default (Linux, macOS, modern Windows with beta UTF-8 support enabled).